### PR TITLE
Enable running with uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Installation
 2. Enter the directory: `cd lsd_viz`
 3. Install the requirements: `pip install -r requirements.txt`
 
-Or, using [uv](https://github.com/astral-sh/uv): `uv run python lsdviz.py`
+Or, using [uv](https://github.com/astral-sh/uv): `uv run python lsdviz.py /path/to/your_song.mp3`
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Usage
 
 To analyze a song, run the following command:
 ```
-python lsd_viz.py /path/to/your_song.mp3
+python lsdviz.py /path/to/your_song.mp3
 ```
 
 By default, this will launch a local web server on port 9999.  To view the analysis, point your web browser at (http://127.0.0.1:9999/).
 
-To change the port and host configuration, see the command-line options by saying `python lsd_viz.py -h`.
+To change the port and host configuration, see the command-line options by saying `python lsdviz.py -h`.
 
 Description
 ===========

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Installation
 2. Enter the directory: `cd lsd_viz`
 3. Install the requirements: `pip install -r requirements.txt`
 
+Or, using [uv](https://github.com/astral-sh/uv): `uv run python lsdviz.py`
+
 
 Usage
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "lsd-viz"
+version = "0.1.0"
+requires-python = "==3.11.*"
+dependencies = [
+    "flask>=3.1.0",
+    "librosa>=0.5",
+    "numpy>=1.10",
+    "scikit-learn>=0.17",
+    "scipy>=0.18",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@ scipy >= 0.18
 librosa >= 0.5
 scikit-learn >= 0.17
 flask
-json
-


### PR DESCRIPTION
This PR enables running lsd_viz with [uv](https://github.com/astral-sh/uv):

`uv run python lsdviz.py /path/to/your_song.mp3`

This PR adds `pyproject.toml` which specifies the required dependencies and Python version (3.11). `uv run` automatically installs those requirements in an isolated virtual environment. If the user does not already have Python 3.11, then uv automatically downloads and installs it in isolation from other Python versions. 

lsd_viz does not work in Python 3.12, because the following line raises `SyntaxWarning: invalid escape sequence '\d'`.

https://github.com/bmcfee/lsd_viz/blob/426f9e03e9bcf3418ce0c3937b1ed8f5f3a4f67b/lsdviz.py#L60

Instead of changing that line of code, I just used Python 3.11, which worked.